### PR TITLE
improve motor current safety check

### DIFF
--- a/FPGA1394_QLA/Verilog/Constants.v
+++ b/FPGA1394_QLA/Verilog/Constants.v
@@ -74,7 +74,7 @@
 `define OFF_RUN_DATA  4'hA         // enc running counter offset
 `define OFF_MOTOR_CONFIG 4'hB      // motor configuration
 `define OFF_MOTOR_STATUS 4'hC      // motor status
-`define OFF_UNUSED_13 4'hD
+`define OFF_MOTOR_SAFETY 4'hD      // motor saftey (current limit)
 `define OFF_UNUSED_14 4'hE
 `define OFF_UNUSED_15 4'hF
 

--- a/FPGA1394_QLA/Verilog/MotorChannelQLA.v
+++ b/FPGA1394_QLA/Verilog/MotorChannelQLA.v
@@ -32,6 +32,7 @@ module MotorChannelQLA
     input wire mv_amp_disable,       // disable amp for short time after mv_good
     input wire wdog_timeout,         // 1 -> watchdog timeout
     input wire amp_fault,            // amplifier fault feedback
+    input wire amp_disable_error,    // 1 -> error in amp_disable output (DQLA only)
     input wire cur_ctrl_error,       // 1 -> error in cur_ctrl output
     input wire disable_f_error,      // 1 -> error in disable_f output
     output wire amp_disable_pin,     // signal to drive FPGA pin
@@ -134,9 +135,10 @@ endgenerate
 
 // Motor Status
 //
-//   31:30   00
-//      29   ~reg_disable
-//      28   ~amp_disable
+//      31   0
+//      30   amp_disable_error (1 -> error with amp_disable output, DQLA only)
+//      29   amp_fault (active low, 1 -> amplifier on)
+//      28   ~reg_disable
 //   27:24   ctrl_mode
 //   23:21   000
 //      20   cur_ctrl (1-> current control)
@@ -147,7 +149,7 @@ endgenerate
 //    15:0   cur_cmd (last setpoint)
 //
 // NOTE: if bit assignments changed, check if QLA.v needs to be updated
-assign motor_status = { 2'b00, ~reg_disable, ~amp_disable, ctrl_mode, 3'd0, cur_ctrl,
+assign motor_status = { 1'b0, amp_disable_error, amp_fault, ~reg_disable, ctrl_mode, 3'd0, cur_ctrl,
                         cur_ctrl_error, disable_f_error, safety_amp_disable, amp_fault_fb,
                         cur_cmd};
 

--- a/FPGA1394_QLA/Verilog/QLA.v
+++ b/FPGA1394_QLA/Verilog/QLA.v
@@ -107,7 +107,6 @@ assign reg_rdata = (reg_raddr[15:12]==`ADDR_PROM_QLA) ? (reg_rdata_prom_qla) :
 // Unused channel offsets
 assign reg_rd[`OFF_UNUSED_02] = 32'd0;
 assign reg_rd[`OFF_UNUSED_03] = 32'd0;
-assign reg_rd[`OFF_UNUSED_13] = 32'd0;
 assign reg_rd[`OFF_UNUSED_14] = 32'd0;
 assign reg_rd[`OFF_UNUSED_15] = 32'd0;
 


### PR DESCRIPTION
There is no current safety check in voltage-control mode. This PR added feature that triggers amplifier disable when current exceeds a preset limit. The limit is now hardcoded to be 200mA for all motor axis, but configurability is also implemented. 